### PR TITLE
Bug fix remain prev frame pixel

### DIFF
--- a/Source/GifSplitter/Private/GifFactory.cpp
+++ b/Source/GifSplitter/Private/GifFactory.cpp
@@ -150,11 +150,11 @@ uint32 UGifFactory::ParseFrame(long IndexX, long IndexY, GIF_WHDR* GifFrame, FGi
 
 	if (OutFrame == 0)
 	{
-		OutFrame = GifData->LastValidPixel[Index];
+		OutFrame = GifData->BeforePixel[Index];
 	}
 	else
 	{
-		GifData->LastValidPixel[Index] = OutFrame;
+		GifData->BeforePixel[Index] = OutFrame;
 	}
 
 	if (IsXInFrame && IsYInFrame)

--- a/Source/GifSplitter/Private/GifFactory.cpp
+++ b/Source/GifSplitter/Private/GifFactory.cpp
@@ -154,7 +154,7 @@ uint32 UGifFactory::ParseFrame(long IndexX, long IndexY, GIF_WHDR* GifFrame, FGi
 	}
 	else
 	{
-		GifData->BeforePixel[Index] = OutFrame;
+		GifData->LastValidPixel[Index] = OutFrame;
 	}
 
 	if (IsXInFrame && IsYInFrame)


### PR DESCRIPTION
opp `spr_m_traveler_duck_anim.gif` 리소스에서 확인

현재 프레임 바깥에 데이터들이 `BeforePixel`이 아니라 `LastValidPixel`을 가져오고 있어서 BKGD 처리로 배경으로 프레임을 채워도 배경색이 아닌 색을 채우고 있었음